### PR TITLE
fix protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "msw-snapshot",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "msw-snapshot",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "devDependencies": {
         "@fastify/compress": "^6.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,7 +212,9 @@ async function createSnapshotPath(info: Info & { context: typeof context }, conf
   return [
     context.namespace,
     info.request.method,
-    url.origin,
+    url.protocol.replace(/:/g, ''),
+    url.hostname,
+    url.port || 'default-port',
     url.pathname,
   ].join('/') + '/' + toHashString([
     getSortedEntries(url.searchParams),


### PR DESCRIPTION
Fixes #6

- Using `url.protocol` which can be `http:` or `https:`, etc. Removing `:` from it.
- Using `url.hostname` - doesn't have schema with `:` and doesn't have port with `:`
- Adding `url.port || 'default-port'` because port isn't present in `url.hostname`

Hopefully this makes sense, cheers!