### PR TITLE
Add compression header filtering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,8 +120,13 @@ export const snapshot = (config: SnapshotConfig): HttpHandler => {
       try {
         const snapshot = JSON.parse(readFileSync(snapshotPath).toString('utf8')) as Snapshot;
         config.onFetchFromSnapshot?.(clonedInfo(), snapshot);
+        const filteredHeaders = snapshot.response.headers.filter(
+          ([key, _]) =>
+          !key.toLowerCase().includes('content-encoding') &&
+          !key.toLowerCase().includes('transfer-encoding')
+        );
         return new Response(new TextEncoder().encode(snapshot.response.body), {
-          headers: new Headers(snapshot.response.headers),
+          headers: new Headers(filteredHeaders),
           status: snapshot.response.status,
           statusText: snapshot.response.statusText,
         });
@@ -160,8 +165,15 @@ export const snapshot = (config: SnapshotConfig): HttpHandler => {
       config.onSnapshotUpdated?.(clonedInfo(), snapshot);
     }
 
+    // Filter out compression-related headers since we're manually handling the body
+    const filteredHeaders = snapshot.response.headers.filter(
+      ([key, _]) =>
+      !key.toLowerCase().includes('content-encoding') &&
+      !key.toLowerCase().includes('transfer-encoding')
+    );
+
     return new Response(new TextEncoder().encode(snapshot.response.body), {
-      headers: new Headers(snapshot.response.headers),
+      headers: new Headers(filteredHeaders),
       status: snapshot.response.status,
       statusText: snapshot.response.statusText,
     });


### PR DESCRIPTION
When snapshots are saved to disk, they may contain `content-encoding: br` headers. Sending these back to the client without compression will cause the client to throw a "Decompression failed" error.

An alternative fix would be to do compression locally, but that's be wasteful and make tests slower. So, it's better to have a policy of removing transport compression when using snapshots.